### PR TITLE
🐛 Fix caching issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,6 +51,11 @@ app.use(bodyParser.json());
 
 app.use(cors());
 
+app.use((req, res, next) => {
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
+  next();
+});
+
 function authenticator(req, res, next) {
   const { authorization } = req.headers;
   if (authorization === token) {


### PR DESCRIPTION
Hi!

The server had no cache control so the browser was caching the response and then if we edited something and went back to a react route that listed our friends it would get the cached version from disk and our edit would not be applied.

This change tells the browser to not cache replies.
